### PR TITLE
refactoring the video filename (remove pk based on uuid)

### DIFF
--- a/app/stt.py
+++ b/app/stt.py
@@ -227,7 +227,7 @@ def STT_with_json(audio_file, jsons):
 
     filler_ratio = round(100*filler_total_time/(audio_total_length - first_silence - silence_interval), 2)
     stt_filler_score, stt_feedback = calculate_filler_score(filler_ratio)
-    stt_score_feedback_json.append({'불필요한 추임새 제어 점수' : stt_filler_score,
+    stt_score_feedback_json.append({'발표 유창성 점수' : stt_filler_score,
                                     '발표 유창성 피드백' : stt_feedback})
 
     statistics_filler_json.append({'어': filler_1,


### PR DESCRIPTION
제스처, 시선추적 API에서 upload된 비디오와 피드백 처리 된 output 비디오 저장 시, 비디오명 리팩토링

- Response Body에서 uuid 기반 pk 삭제
- 제스처 video_filename을 "(업로드비디오명)_gesture_(날짜시간)"로 통일
- 시선추적 video_filename을 "(업로드비디오명)_eyecontact_(날짜시간)"로 통일