### PR TITLE
Updated README.md : remove .env in directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ AI_SERVER
 │   ├── filler_classifier_model.h5
 │   ├── filter_determine_model.h5
 │   └── gesture_XGB_model.pkl
-├── .env
 ├── .gitignore
 ├── Dockerfile
 ├── README.md


### PR DESCRIPTION
.env 파일이 github에는 올라가지 않게 함
README의 디렉토리 구조에서도 .env 제외