### PR TITLE
Update Dockerfile: use python:3.10.12-slim and install libgl1-mesa-glx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12
+FROM python:3.10.12-slim
 WORKDIR /AI_SERVER
 
 # 필수 시스템 패키지 설치
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     ffmpeg \
     libsm6 \
     libxext6 \
-    libgl1 \
+    libgl1-mesa-glx \
  && rm -rf /var/lib/apt/lists/*
 
 COPY ./requirements.txt /AI_SERVER/requirements.txt


### PR DESCRIPTION
Dockerfile 업데이트
- python:3.10.12 대신 python:3.10.12-slim 이미지 사용  
- libgl1 대신 libgl1-mesa-glx 설치