### PR TITLE
refactor: Load XGBoost model with GPU predictor and convert from .pkl to .json format

### DIFF
--- a/app/gesture.py
+++ b/app/gesture.py
@@ -7,6 +7,13 @@ import cv2
 import numpy as np
 import mediapipe as mp
 import joblib
+import xgboost as xgb
+
+# 기존 .pkl 모델 로드
+model = joblib.load('gesture_XGB_model.pkl')
+
+# GPU에서 사용할 수 있도록 json으로 저장
+model.save_model('gesture_XGB_model.json')
 
 app_dir = os.path.dirname(__file__)
 project_root = os.path.dirname(app_dir)
@@ -91,8 +98,9 @@ def draw_info_text(image, brect, facial_text):
 def load_model():
     # 모델 경로 설정
     model_path = os.path.join(project_root, 'models','gesture_XGB_model.pkl')
-    return joblib.load(model_path)
-
+    booster = xgb.Booster({'predictor': 'gpu_predictor'})
+    booster.load_model(model_path)
+    return booster
 
 def body(vid):
     # Rest of your code remains mostly unchanged, with adjustments for the Pose models


### PR DESCRIPTION
-  xgb.Booster()를 써서 predictor="gpu_predictor"로 설정해야 GPU 사용 가능
- 이 방식은 .pkl 대신 .json 형식으로 저장된 XGBoost 모델만 가능