### PR TITLE
Set up SSH key from base64 secret using cat and heredoc(EOF)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,17 @@ jobs:
       - name: Set up SSH key from base64 secret
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.EC2_SSH_KEY }}" | base64 -d > ~/.ssh/id_rsa
+          cat <<EOF | base64 -d > ~/.ssh/id_rsa 
+          ${{ secrets.EC2_SSH_KEY_B64 }} 
+          EOF
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H 3.36.4.163 >> ~/.ssh/known_hosts
+
+       #run: |
+       #   mkdir -p ~/.ssh
+       #   echo "${{ secrets.EC2_SSH_KEY }}" | base64 -d > ~/.ssh/id_rsa
+       #   chmod 600 ~/.ssh/id_rsa
+       #   ssh-keyscan -H 3.36.4.163 >> ~/.ssh/known_hosts
+
 
       - name: Run deploy.sh on EC2
         run: |


### PR DESCRIPTION
base64로 인코딩된 SSH 비밀키를 GitHub Actions에서 디코딩하여 .ssh/id_rsa로 저장하도록 설정
-> CAT, EOF 사용